### PR TITLE
Fix crash when BLE payload is too short

### DIFF
--- a/AirTag_Scanner.ino
+++ b/AirTag_Scanner.ino
@@ -19,6 +19,8 @@ class MyAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks {
       // raw data
       uint8_t* payLoad = advertisedDevice.getPayload();
       size_t payLoadLength = advertisedDevice.getPayloadLength();
+      
+      if (payLoadLength < 4) return ;
 
       // searches both "1E FF 4C 00" and "4C 00 12 19" as the payload can differ slightly
       bool patternFound = false;


### PR DESCRIPTION
Apparently for some devices `advertisedDevice.getPayload()` returns 0, resulting in a random crash in the pattern matching for loop in `onResult()`.
This commit fixes this bug, exiting from `onResult()` if the payload is less than 4 bytes long.